### PR TITLE
Simplify Withdraw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,14 +41,13 @@ contracts
 
 Each vault may have many strategies associated with it, and may allocate capital to strategies via admin controls. 
 ### Withdraw Process
-The vault withdraw process is a critical piece of the vault itself. Due to the relationship between vaults and strategies, a vault is not expected to have access to liquid capital at all times. As such a withdraw process is used to ensure that users are able to withdraw their funds.
+#### V1 Withdraw Process
+The V1 withdraw process has been reduced to its simplist form.
 
-The process is as follows
-- the vault attempts to pay out a withdraw from its capital on hand.
-- If this isn't possible, the vault iterates through all its strategies and requests a withdraw of the outstanding capital (using `strategy.withdraw(amount)`). Each strategy will return as much capital as it can.
-- If the vault still does not have enough capital after iterating through all strategies, it will simply pay out what it can at that point and only burn a portion of the users shares.
-
-During this withdraw process, a strategy may choose to attempt to liquidate some of its positions in order to get this capital. This will mean that the next time the vault calls on a strategy, it should have more capital on hand to provide the vault.
+The following are the steps
+- A user requests a withdraw with the vault. This increases their pending withdraw limit as well as the `totalRequestedWithdraws`. This user is unable to withdraw for 24 hours.
+- the strategy has 24 hours in which these funds should be liquidated. This will increase the `withdrawable` amount of the strategy.
+- The user is then able to withdraw 24 hours later. If funds are not available on hand this withdraw will revert.
 
 ## Strategies
 Todo.

--- a/test/VaultV1.js
+++ b/test/VaultV1.js
@@ -317,20 +317,19 @@ describe("VaultV1", async () => {
         })
     })
 
-    describe("setStrategy", async() => {
-
-        beforeEach(async() => {
+    describe("setStrategy", async () => {
+        beforeEach(async () => {
             // pretend the strategy has some value in it
             mockStrategy.setValue(ethers.utils.parseEther("1"))
         })
 
-        it("reverts if not called by the owner", async() => {
+        it("reverts if not called by the owner", async () => {
             await expect(
                 vault.connect(accounts[2]).setStrategy(accounts[1].address)
             ).to.be.revertedWith("Ownable: caller is not the owner")
         })
 
-        it("reverts if the strategy has deployed funds on hand", async() => {
+        it("reverts if the strategy has deployed funds on hand", async () => {
             await expect(
                 vault.setStrategy(accounts[1].address)
             ).to.be.revertedWith("strategy still active")


### PR DESCRIPTION
# Motivation
It appears the best way to deal with accounting and withdraw complexity is to offload this from the vault to the strategy. In that way, the vault can be agnostic in how it deals with withdraws. It just expects strategies to be ready with the cash. This is good since we now have a withdraw period of 24 hours.

# Changes
- removes `BUFFER`
- simplifies the withdraw process
- updates README.