### PR TITLE
add deposit hook to strategy

### DIFF
--- a/contracts/VaultV1.sol
+++ b/contracts/VaultV1.sol
@@ -47,6 +47,8 @@ contract VaultV1 is ERC4626, Ownable {
     //sends funds from the vault to the strategy address
     function afterDeposit(uint256 amount) internal virtual override {
         underlying.safeTransfer(address(strategy), amount);
+        // notify the strategy
+        strategy.deposit(amount);
     }
 
     /**

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -27,9 +27,9 @@ interface IStrategy {
     function withdraw(uint256 amount) external;
 
     /**
-    * @notice deposits into the strategy
-    * @dev this hook can be used to update and strategy state / deposit into external contracts
-    */
+     * @notice deposits into the strategy
+     * @dev this hook can be used to update and strategy state / deposit into external contracts
+     */
     function deposit(uint256 amount) external;
 
     function requestWithdraw(uint256 amount) external;

--- a/contracts/interfaces/IStrategy.sol
+++ b/contracts/interfaces/IStrategy.sol
@@ -26,5 +26,11 @@ interface IStrategy {
      */
     function withdraw(uint256 amount) external;
 
+    /**
+    * @notice deposits into the strategy
+    * @dev this hook can be used to update and strategy state / deposit into external contracts
+    */
+    function deposit(uint256 amount) external;
+
     function requestWithdraw(uint256 amount) external;
 }

--- a/contracts/strategies/PermissionedStrategy.sol
+++ b/contracts/strategies/PermissionedStrategy.sol
@@ -106,9 +106,9 @@ contract PermissionedStrategy is IStrategy, AccessControl {
     }
 
     /**
-    * @notice deposits into the strategy
-    * @dev this hook can be used to update and strategy state / deposit into external contracts
-    */
+     * @notice deposits into the strategy
+     * @dev this hook can be used to update and strategy state / deposit into external contracts
+     */
     function deposit(uint256 amount) external override onlyVault {
         // no deposit hook required for this strategy
     }

--- a/contracts/strategies/PermissionedStrategy.sol
+++ b/contracts/strategies/PermissionedStrategy.sol
@@ -105,6 +105,14 @@ contract PermissionedStrategy is IStrategy, AccessControl {
         VAULT_ASSET.transfer(VAULT, amountToTransfer);
     }
 
+    /**
+    * @notice deposits into the strategy
+    * @dev this hook can be used to update and strategy state / deposit into external contracts
+    */
+    function deposit(uint256 amount) external override onlyVault {
+        // no deposit hook required for this strategy
+    }
+
     /*///////////////////////////////////////////////////////////////
                             External Access Functions
     //////////////////////////////////////////////////////////////*/

--- a/contracts/utils/MockStrategy.sol
+++ b/contracts/utils/MockStrategy.sol
@@ -57,12 +57,10 @@ contract MockStrategy is IStrategy, AccessControl {
     }
 
     /**
-    * @notice deposits into the strategy
-    * @dev this hook can be used to update and strategy state / deposit into external contracts
-    */
-    function deposit(uint256 amount) external override {
-
-    }
+     * @notice deposits into the strategy
+     * @dev this hook can be used to update and strategy state / deposit into external contracts
+     */
+    function deposit(uint256 amount) external override {}
 
     /**
      * @dev this function is helpful for testing. It allows you to arbitrarily move funds

--- a/contracts/utils/MockStrategy.sol
+++ b/contracts/utils/MockStrategy.sol
@@ -57,6 +57,14 @@ contract MockStrategy is IStrategy, AccessControl {
     }
 
     /**
+    * @notice deposits into the strategy
+    * @dev this hook can be used to update and strategy state / deposit into external contracts
+    */
+    function deposit(uint256 amount) external override {
+
+    }
+
+    /**
      * @dev this function is helpful for testing. It allows you to arbitrarily move funds
      * out of a strategy
      */


### PR DESCRIPTION
# Motivation
A deposit hook allows us to notify the strategy when a deposit occurs. This enables it to react to a deposit (eg on deposit send funds to another protocol, etc).

# Changes
- adds `deposit` function to strategy
- updates existing strategies and mock strategies